### PR TITLE
don't change the original brightness when iOS auto-brightness

### DIFF
--- a/ios/KeepScreenOn/KeepScreenOn.m
+++ b/ios/KeepScreenOn/KeepScreenOn.m
@@ -80,15 +80,9 @@ RCT_EXPORT_MODULE();
         newView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         
         [root addSubview:newView];
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(brightnessDidChange:) name:UIScreenBrightnessDidChangeNotification object:nil];
     }
     
     return self;
-}
-
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 // get the Root React native View
@@ -99,11 +93,6 @@ RCT_EXPORT_MODULE();
     }
     
     return nil;
-}
-
-// event coming from system brightness settings
-- (void)brightnessDidChange: (NSNotification *)notification {
-    _originalBrightness = [UIScreen mainScreen].brightness;
 }
 
 // user tapped the screen


### PR DESCRIPTION
The UISCreenBrightnessDIDChangeNotification gets called when iOS changes the brightness automatically based on lighting conditions. This was causing a somewhat weird behavior with auto-dimming: 
- the screen would dim after 10 sec via our auto-dimmer
- while dim, iOS would slightly brighten the screen
- this value was stored as the 'original' brightness
- user interacts with screen
- nothing or very little happens
- device setting is now dimmed, user thinks our app did it, even though it was iOS

Solution, don't update 'original' brightness
- as before, 'original' brightness is stored when app becomes active (this happens in RN JS via autoDimOnChangedAppState)
- hopefully will be less annoying for users
